### PR TITLE
Add frequency visualization option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,16 @@ pip install pygame sounddevice soundfile numpy
 
 ## Running
 
-To visualize microphone input:
+To visualize microphone input in amplitude mode:
 
 ```bash
 python src/visualizer.py
+```
+
+To visualize microphone input in frequency mode:
+
+```bash
+python src/visualizer.py --mode frequency
 ```
 
 To visualize a specific audio file (e.g., `song.wav`):
@@ -29,4 +35,10 @@ To visualize a specific audio file (e.g., `song.wav`):
 python src/visualizer.py song.wav
 ```
 
-A window will open showing a dynamic bar that reacts to the audio amplitude.
+You can also display frequency bars for the file:
+
+```bash
+python src/visualizer.py song.wav --mode frequency
+```
+
+A window will open showing bars that react to the audio input.


### PR DESCRIPTION
## Summary
- add a `--mode` flag to switch between amplitude and frequency visualization
- compute bass/mid/high bands with numpy FFT
- render multiple bars in frequency mode
- update README with new usage examples

## Testing
- `python -m py_compile src/visualizer.py`

------
https://chatgpt.com/codex/tasks/task_e_68888ab9cbc88328864dd82985aceb3c